### PR TITLE
Ensure strings are null-terminated in binary writer

### DIFF
--- a/shared/IO/file_io.py
+++ b/shared/IO/file_io.py
@@ -115,8 +115,10 @@ class BinaryWriter:
             if type == 'void':
                 return
             elif type == 'string':
-                # TODO: confirm if this includes null terminator byte
-                self.file.write(bytes(data, 'utf-8'))
+                encoded = bytes(data, 'utf-8')
+                # Strings in DAT files are null-terminated, so ensure the
+                # terminator byte is written alongside the encoded data.
+                self.file.write(encoded + b'\x00')
             elif type == 'vec3':
                 for i in range(3):
                     self.file.write(struct.pack('>f', data[i]))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import sys
+import types
+
+# Provide stub modules for Blender-specific imports used in package init
+sys.modules.setdefault('bpy', types.ModuleType('bpy'))
+
+bpy_extras = types.ModuleType('bpy_extras')
+io_utils = types.ModuleType('io_utils')
+io_utils.ImportHelper = object
+io_utils.ExportHelper = object
+io_utils.axis_conversion = lambda *args, **kwargs: None
+bpy_extras.io_utils = io_utils
+sys.modules.setdefault('bpy_extras', bpy_extras)
+sys.modules.setdefault('bpy_extras.io_utils', io_utils)

--- a/tests/test_string_io.py
+++ b/tests/test_string_io.py
@@ -1,0 +1,56 @@
+import os
+import pathlib
+import tempfile
+import importlib.util
+import types
+import sys
+
+
+# Import file_io without executing shared.IO.__init__ (which pulls in bpy)
+repo_root = pathlib.Path(__file__).resolve().parents[1]
+shared_path = repo_root / "shared"
+io_path = shared_path / "IO"
+
+# Create package stubs for shared and shared.IO to satisfy relative imports
+shared_pkg = types.ModuleType("shared")
+shared_pkg.__path__ = [str(shared_path)]
+sys.modules.setdefault("shared", shared_pkg)
+
+io_pkg = types.ModuleType("shared.IO")
+io_pkg.__path__ = [str(io_path)]
+sys.modules.setdefault("shared.IO", io_pkg)
+
+FILE_IO_PATH = io_path / "file_io.py"
+spec = importlib.util.spec_from_file_location("shared.IO.file_io", FILE_IO_PATH)
+file_io = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = file_io
+spec.loader.exec_module(file_io)
+BinaryReader = file_io.BinaryReader
+BinaryWriter = file_io.BinaryWriter
+
+
+def test_string_roundtrip():
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    try:
+        path = tmp.name
+        tmp.close()
+
+        writer = BinaryWriter(path)
+        writer.write('string', 'hello')
+        writer.close()
+
+        with open(path, 'rb') as f:
+            data = f.read()
+        assert data == b'hello\x00'
+
+        reader = BinaryReader(path)
+        result = reader.read('string', 0)
+        reader.close()
+        assert result == 'hello'
+    finally:
+        os.remove(path)
+
+
+if __name__ == "__main__":
+    test_string_roundtrip()
+    print("test_string_roundtrip passed")


### PR DESCRIPTION
## Summary
- append null terminator when writing string primitives
- add regression test confirming string roundtrip includes terminator

## Testing
- `python tests/test_string_io.py`
- `pip install bpy` *(fails: Could not find a version that satisfies the requirement bpy)*

------
https://chatgpt.com/codex/tasks/task_e_68c64ae209cc832693634c65a0824e79