### PR TITLE
Initialize MaterialObject fields for export

### DIFF
--- a/shared/Nodes/Classes/Material/MaterialObject.py
+++ b/shared/Nodes/Classes/Material/MaterialObject.py
@@ -17,6 +17,15 @@ class MaterialObject(Node):
         ('pixel_engine_data', 'PixelEngine'),
     ]
 
+    def __init__(self, address, blender_obj):
+        super().__init__(address, blender_obj)
+        self.class_type = ""
+        self.render_mode = 0
+        self.texture = None
+        self.material = None
+        self.render_data = None
+        self.pixel_engine_data = None
+
     def loadFromBinary(self, parser):
         super().loadFromBinary(parser)
         self.id = self.address


### PR DESCRIPTION
## Summary
- Initialize default fields in `MaterialObject` so exports don't fail when fields are missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mathutils')*

------
https://chatgpt.com/codex/tasks/task_e_68c65aaba7bc8326b96aaa54d59416fc