### PR TITLE
Add validation for node class instantiation

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -19,8 +19,18 @@ import bpy
 import os
 from bpy_extras.io_utils import ImportHelper, ExportHelper, axis_conversion
 
-from .exporter import exporter
-from .importer import importer
+IN_BLENDER = hasattr(bpy, "app")
+
+if IN_BLENDER:
+    if __package__:
+        from .exporter import exporter
+        from .importer import importer
+    else:  # pragma: no cover - fallback for running outside Blender package context
+        from exporter import exporter  # type: ignore
+        from importer import importer  # type: ignore
+else:  # pragma: no cover - skip heavy imports when running tests without Blender
+    exporter = None  # type: ignore
+    importer = None  # type: ignore
 
 
 # This class declares global properties which blender uses to add toggles and fields to the file open browser

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/test_dat_write.py
+++ b/test_dat_write.py
@@ -1,4 +1,13 @@
+import pytest
+
 import bpy
+
+# The write round-trip test requires Blender's Python API. Skip it when the
+# stubs from the unit test environment are in use so the rest of the suite can
+# run without Blender installed.
+if not hasattr(bpy, "ops"):
+    pytest.skip("Blender context not available for integration test", allow_module_level=True)
+
 from shared.IO.DAT_io import DATParser, DATBuilder
 from shared.IO.ModelBuilder import ModelBuilder
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,45 @@
+from pathlib import Path
 import sys
 import types
 
-# Provide stub modules for Blender-specific imports used in package init
-sys.modules.setdefault('bpy', types.ModuleType('bpy'))
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+# Provide stub modules for Blender-specific imports used in package init.
+# These stubs are intentionally lightweight – the tests only need the
+# modules to exist so imports succeed. When running inside Blender these
+# branches will be skipped and the real modules will be used instead.
+if 'bpy' not in sys.modules:
+    bpy_module = types.ModuleType('bpy')
+
+    class _Menu:
+        def append(self, *_args, **_kwargs):
+            return None
+
+        def remove(self, *_args, **_kwargs):
+            return None
+
+    bpy_module.types = types.SimpleNamespace(
+        Operator=type('Operator', (), {}),
+        OperatorFileListElement=type('OperatorFileListElement', (), {}),
+        TOPBAR_MT_file_import=_Menu(),
+        TOPBAR_MT_file_export=_Menu(),
+    )
+    bpy_module.props = types.SimpleNamespace(
+        CollectionProperty=lambda *args, **kwargs: None,
+        StringProperty=lambda *args, **kwargs: None,
+        BoolProperty=lambda *args, **kwargs: None,
+        IntProperty=lambda *args, **kwargs: None,
+    )
+    bpy_module.utils = types.SimpleNamespace(
+        register_class=lambda *args, **kwargs: None,
+        unregister_class=lambda *args, **kwargs: None,
+    )
+
+    sys.modules['bpy'] = bpy_module
 
 bpy_extras = types.ModuleType('bpy_extras')
 io_utils = types.ModuleType('io_utils')
@@ -12,3 +49,77 @@ io_utils.axis_conversion = lambda *args, **kwargs: None
 bpy_extras.io_utils = io_utils
 sys.modules.setdefault('bpy_extras', bpy_extras)
 sys.modules.setdefault('bpy_extras.io_utils', io_utils)
+
+
+# Minimal mathutils stub so modules that depend on Blender's math classes can
+# be imported in the test environment.
+if 'mathutils' not in sys.modules:
+    mathutils = types.ModuleType('mathutils')
+
+    class _Matrix:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        @staticmethod
+        def Translation(*args, **kwargs):
+            return _Matrix()
+
+        @staticmethod
+        def Rotation(*args, **kwargs):
+            return _Matrix()
+
+        @staticmethod
+        def Scale(*args, **kwargs):
+            return _Matrix()
+
+        def to_3x3(self):
+            return self
+
+        def to_4x4(self):
+            return self
+
+        def invert(self):
+            return self
+
+        def transpose(self):
+            return self
+
+        def inverted(self):
+            return self
+
+        def transposed(self):
+            return self
+
+        def identity(self):
+            return self
+
+        def __matmul__(self, other):
+            return self
+
+        def __rmatmul__(self, other):
+            return self
+
+        def __imatmul__(self, other):
+            return self
+
+        def __mul__(self, other):
+            return self
+
+        def __rmul__(self, other):
+            return self
+
+    class _Vector:
+        def __init__(self, values=None):
+            self.values = tuple(values) if values is not None else tuple()
+
+        def normalized(self):
+            return self
+
+    class _Euler:
+        def __init__(self, values=None):
+            self.values = tuple(values) if values is not None else tuple()
+
+    mathutils.Matrix = _Matrix
+    mathutils.Vector = _Vector
+    mathutils.Euler = _Euler
+    sys.modules['mathutils'] = mathutils

--- a/tests/test_node_instantiation.py
+++ b/tests/test_node_instantiation.py
@@ -1,0 +1,62 @@
+"""Validation tests for node class definitions.
+
+These tests ensure that every node class can be instantiated with the
+arguments used by the binary parser and that each field definition points to a
+known primitive type or another registered node class. This guards against
+regressions where refactors leave a class with mismatched constructor
+signatures or dangling type names in the ``fields`` metadata used by the
+parser.
+"""
+
+from shared.ClassLookup.get_class_from_name import get_class_from_name
+from shared.Constants.PrimitiveTypes import is_primitive_type
+from shared.Constants.RecursiveTypes import getSubType
+from shared.Nodes import Node
+from shared.Nodes.NodeTypes import markUpFieldType
+
+
+def _iter_node_classes():
+    """Yield every concrete subclass of :class:`Node`."""
+
+    seen = set()
+    stack = list(Node.__subclasses__())
+    while stack:
+        cls = stack.pop()
+        if cls in seen:
+            continue
+        seen.add(cls)
+        yield cls
+        stack.extend(cls.__subclasses__())
+
+
+def test_node_classes_have_valid_field_definitions():
+    """All node classes should instantiate and reference known field types."""
+
+    for cls in _iter_node_classes():
+        instance = cls(0, None)
+
+        assert hasattr(instance, "fields"), f"{cls.__name__} missing fields attribute"
+        assert isinstance(instance.fields, list), (
+            f"{cls.__name__}.fields should be a list, got {type(instance.fields)!r}"
+        )
+
+        for field in instance.fields:
+            assert isinstance(field, tuple) and len(field) == 2, (
+                f"{cls.__name__}.fields entries must be (name, type) tuples"
+            )
+            field_name, field_type = field
+            assert isinstance(field_name, str) and field_name, (
+                f"{cls.__name__} has invalid field name {field_name!r}"
+            )
+            assert isinstance(field_type, str) and field_type, (
+                f"{cls.__name__}.{field_name} must declare a type"
+            )
+
+            subtype = getSubType(markUpFieldType(field_type))
+            if is_primitive_type(subtype):
+                continue
+
+            resolved = get_class_from_name(subtype)
+            assert (
+                resolved is not None
+            ), f"{cls.__name__}.{field_name} references unknown node type {subtype!r}"


### PR DESCRIPTION
## Summary
- make the add-on module tolerant of running without Blender by guarding heavy imports
- provide lightweight Blender and mathutils stubs along with a pytest configuration for unit tests
- add coverage that instantiates every node class to ensure their field definitions resolve correctly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9a7ece9d883269e58046f190a5d97