### PR TITLE
Handle None node pointers during DAT export

### DIFF
--- a/shared/IO/DAT_io.py
+++ b/shared/IO/DAT_io.py
@@ -411,25 +411,48 @@ class DATBuilder(BinaryWriter):
             field_type = markUpFieldType(field[1])
             field_value = getattr(node, field_name)
             field_length = get_type_length(field_type)
+            raw_field_type = field_type
+            while isBracketedType(raw_field_type):
+                raw_field_type = getBracketedSubType(raw_field_type)
 
             # Dump values that are pointed to first and replace them with their pointers
-            if isPointerType(field_type):
-                sub_type = getPointerSubType(field_type)
-                pointer = self.write(field_value, sub_type)
+            if isPointerType(raw_field_type) and field[1] != 'string':
+                sub_type = getPointerSubType(raw_field_type)
+                if field_value is None:
+                    pointer = 0
+                else:
+                    pointer = self.write(field_value, sub_type)
                 setattr(node, field_name, pointer)
 
-            elif isNodeClassType(field_type):
-                pointer = self.write(field_value, field_type)
-                field_value.address = pointer
+            elif isNodeClassType(raw_field_type):
+                if not field_value:
+                    pointer = 0
+                elif hasattr(field_value, 'address'):
+                    pointer = self.write(field_value, raw_field_type)
+                    field_value.address = pointer
+                else:
+                    pointer = field_value
                 setattr(node, field_name, pointer)
 
-            elif isBoundedArrayType(field_type) or isUnboundedArrayType(field_type):
-                sub_type = getArraySubType(field_type)
-                if isPointerType(sub_type) or isNodeClassType(sub_type):
+            elif isBoundedArrayType(raw_field_type) or isUnboundedArrayType(raw_field_type):
+                sub_type = getArraySubType(raw_field_type)
+                raw_sub_type = sub_type
+                while isBracketedType(raw_sub_type):
+                    raw_sub_type = getBracketedSubType(raw_sub_type)
+
+                if isPointerType(raw_sub_type) or isNodeClassType(raw_sub_type):
+                    if field_value is None:
+                        setattr(node, field_name, field_value)
+                        continue
+
                     pointers_array = []
                     for value in field_value:
+                        if value is None:
+                            pointers_array.append(value)
+                            continue
+
                         pointer = self.write(value, sub_type)
-                        if isNodeClassType(sub_type):
+                        if isNodeClassType(raw_sub_type) and hasattr(value, 'address'):
                             value.address = pointer
                         pointers_array.append(value)
 

--- a/tests/test_dat_builder_none_pointers.py
+++ b/tests/test_dat_builder_none_pointers.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+from shared.IO.DAT_io import DATBuilder
+from shared.Nodes.Classes.Material.MaterialObject import MaterialObject
+
+
+def test_write_node_handles_none_children(tmp_path: Path) -> None:
+    material = MaterialObject(0, None)
+
+    output_path = tmp_path / "material.dat"
+    builder = DATBuilder(str(output_path), [])
+
+    try:
+        builder.writeNode(material, relative_to_header=True)
+    finally:
+        builder.close()
+
+    assert material.texture == 0
+    assert material.material == 0
+    assert material.render_data == 0
+    assert material.pixel_engine_data == 0
+
+    data = output_path.read_bytes()
+    base_offset = DATBuilder.DAT_header_length
+    pointer_offsets = [base_offset + 8, base_offset + 12, base_offset + 16, base_offset + 20]
+
+    for offset in pointer_offsets:
+        pointer_value = int.from_bytes(data[offset:offset + 4], byteorder="big")
+        assert pointer_value == 0


### PR DESCRIPTION
## Summary
- ensure DATBuilder.writeNode treats missing pointer and node references as zero without dereferencing attributes
- update array handling to skip None elements when writing nested node and pointer lists
- add a regression test that exports a bare MaterialObject and verifies zeroed pointer fields

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9afc7f4b8832684a3301197bb9ae3