### PR TITLE
Fix exporter texture nodes missing defaults

### DIFF
--- a/exporter/exporter.py
+++ b/exporter/exporter.py
@@ -101,8 +101,13 @@ class Exporter:
     def _collect_texture_nodes():
         """Convert Blender textures/images to TextureNode objects."""
         texture_nodes = []
-        for img in bpy.data.images:
+        data = getattr(bpy, "data", None)
+        images = getattr(data, "images", []) if data is not None else []
+
+        for index, img in enumerate(images or []):
             tex_node = Texture(address=None, blender_obj=img)
+            tex_node.name = getattr(img, "name", f"texture_{index}") or f"texture_{index}"
+            tex_node.texture_id = index
             try:
                 tex_node.path = img.filepath_from_user() if hasattr(img, "filepath_from_user") else getattr(img, "filepath", "")
             except Exception:
@@ -116,6 +121,9 @@ class Exporter:
 
             tex_node.format = Exporter._deduce_image_format(img)
             texture_nodes.append(tex_node)
+
+        for idx in range(len(texture_nodes) - 1):
+            texture_nodes[idx].next = texture_nodes[idx + 1]
         return texture_nodes
 
     # ---------- MESHES ----------

--- a/shared/Nodes/Classes/Texture/Texture.py
+++ b/shared/Nodes/Classes/Texture/Texture.py
@@ -24,6 +24,27 @@ class Texture(Node):
         ('tev', 'TextureTEV'),
     ]
 
+    def __init__(self, address, blender_obj):
+        super().__init__(address, blender_obj)
+        self.name = ""
+        self.next = None
+        self.texture_id = 0
+        self.source = 0
+        self.rotation = (0.0, 0.0, 0.0)
+        self.scale = (1.0, 1.0, 1.0)
+        self.translation = (0.0, 0.0, 0.0)
+        self.wrap_s = 0
+        self.wrap_t = 0
+        self.repeat_s = 0
+        self.repeat_t = 0
+        self.flags = 0
+        self.blending = 0.0
+        self.mag_filter = 0
+        self.image = None
+        self.palette = None
+        self.lod = None
+        self.tev = None
+
     def loadFromBinary(self, parser):
         super().loadFromBinary(parser)
         self.id = self.address


### PR DESCRIPTION
## Summary
- initialize Texture nodes with default values so DATBuilder can access expected fields
- assign texture names and ids when collecting Blender images to stabilise export

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9f366fba08326816d8c572e254952