### PR TITLE
Ensure node instantiation tests cover mesh and texture classes

### DIFF
--- a/shared/Nodes/Node.py
+++ b/shared/Nodes/Node.py
@@ -1,5 +1,27 @@
-from .NodeTypes import get_type_length
 from collections import deque
+
+from .NodeTypes import get_type_length, markUpFieldType
+from ..Constants.PrimitiveTypes import is_primitive_type
+from ..Constants.RecursiveTypes import (
+    getArraySubType,
+    getArrayTypeBound,
+    getBracketedSubType,
+    getPointerSubType,
+    getSubType,
+    isBoundedArrayType,
+    isBracketedType,
+    isPointerType,
+    isUnboundedArrayType,
+)
+
+
+def _identity_matrix():
+    return [
+        [1.0, 0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0, 0.0],
+        [0.0, 0.0, 0.0, 1.0],
+    ]
 
 
 # Abstract node class
@@ -38,6 +60,137 @@ class Node(object):
         self.is_being_printed = False
         self.is_being_listed = False
         self.is_prepared_for_build = False
+
+        self._initialize_field_defaults()
+
+    def _initialize_field_defaults(self):
+        for field_info in getattr(self, 'fields', []):
+            field_name, field_type = field_info[0], field_info[1]
+            if hasattr(self, field_name):
+                continue
+            default_value = self._default_value_for_field(field_type)
+            setattr(self, field_name, default_value)
+
+    @classmethod
+    def _default_value_for_field(cls, field_type):
+        if not field_type:
+            return None
+
+        clean_type = field_type.replace(' ', '')
+
+        if cls._type_has_array(clean_type):
+            element_type = cls._array_element_type(clean_type)
+            bound = cls._array_bound(clean_type)
+            if bound is None:
+                return []
+            return [cls._default_value_for_field(element_type) for _ in range(bound)]
+
+        canonical_type = markUpFieldType(field_type)
+        unwrapped_type = cls._strip_brackets(canonical_type)
+
+        if isPointerType(unwrapped_type):
+            pointer_target = getPointerSubType(unwrapped_type)
+
+            if cls._canonical_type_is_array(pointer_target):
+                array_sub_type = getArraySubType(pointer_target)
+                bound = getArrayTypeBound(pointer_target)
+                if bound is None:
+                    return []
+                return [cls._default_value_for_field(array_sub_type) for _ in range(bound)]
+
+            base_type = getSubType(pointer_target)
+            if base_type == 'string':
+                return ""
+            if base_type == 'matrix':
+                return _identity_matrix()
+            return None
+
+        if cls._canonical_type_is_array(unwrapped_type):
+            array_sub_type = getArraySubType(unwrapped_type)
+            bound = getArrayTypeBound(unwrapped_type)
+            if bound is None:
+                return []
+            return [cls._default_value_for_field(array_sub_type) for _ in range(bound)]
+
+        base_type = getSubType(unwrapped_type)
+
+        if is_primitive_type(base_type):
+            return cls._primitive_default(base_type)
+
+        if cls._field_is_embedded(clean_type):
+            return cls._instantiate_node_class(base_type)
+
+        return None
+
+    @staticmethod
+    def _strip_brackets(field_type):
+        stripped = field_type
+        while isBracketedType(stripped):
+            stripped = getBracketedSubType(stripped)
+        return stripped
+
+    @staticmethod
+    def _type_has_array(type_string):
+        return ('[' in type_string) and (']' in type_string)
+
+    @staticmethod
+    def _canonical_type_is_array(type_string):
+        return isBoundedArrayType(type_string) or isUnboundedArrayType(type_string)
+
+    @staticmethod
+    def _array_bound(type_string):
+        start = type_string.find('[')
+        end = type_string.find(']', start + 1)
+        if start == -1 or end == -1:
+            return None
+        bound_string = type_string[start + 1:end]
+        if bound_string.isdigit():
+            return int(bound_string)
+        return None
+
+    @staticmethod
+    def _array_element_type(type_string):
+        start = type_string.find('[')
+        if start == -1:
+            return type_string
+        end = type_string.find(']', start + 1)
+        if end == -1:
+            end = len(type_string)
+        return type_string[:start] + type_string[end + 1:]
+
+    @staticmethod
+    def _primitive_default(primitive_type):
+        if primitive_type == 'string':
+            return ""
+        if primitive_type in {'float', 'double'}:
+            return 0.0
+        if primitive_type == 'vec3':
+            return (0.0, 0.0, 0.0)
+        if primitive_type == 'matrix':
+            return _identity_matrix()
+        if primitive_type == 'void':
+            return None
+        return 0
+
+    @staticmethod
+    def _field_is_embedded(type_string):
+        return '@' in type_string
+
+    @staticmethod
+    def _instantiate_node_class(class_name):
+        try:
+            from ..ClassLookup import get_class_from_name
+            class_reference = get_class_from_name(class_name)
+        except Exception:
+            class_reference = None
+
+        if class_reference is None:
+            return None
+
+        try:
+            return class_reference(None, None)
+        except Exception:
+            return None
 
     # Parse struct from binary file.
     # Use the parser to read the binary for the fields and then do any conversions or calculations

--- a/tests/test_node_instantiation_defaults.py
+++ b/tests/test_node_instantiation_defaults.py
@@ -1,0 +1,107 @@
+import importlib
+import inspect
+import pkgutil
+
+import pytest
+
+from shared.Nodes.Node import Node
+import shared.Nodes.Classes as node_classes_module
+
+
+def _iter_node_modules():
+    yield node_classes_module
+
+    package_path = getattr(node_classes_module, "__path__", None)
+    if not package_path:
+        return
+
+    prefix = node_classes_module.__name__ + "."
+    for _, module_name, _ in pkgutil.walk_packages(package_path, prefix):
+        yield importlib.import_module(module_name)
+
+
+def _gather_node_classes():
+    discovered = {}
+
+    for module in _iter_node_modules():
+        for _, cls in inspect.getmembers(module, inspect.isclass):
+            if issubclass(cls, Node) and cls is not Node:
+                discovered.setdefault(cls, cls)
+
+    return tuple(sorted(discovered, key=lambda cls: (cls.__module__, cls.__name__)))
+
+
+NODE_CLASSES = tuple(_gather_node_classes())
+NODE_CLASS_NAMES = {cls.__name__ for cls in NODE_CLASSES}
+
+
+ESSENTIAL_NODE_CLASS_NAMES = {
+    "Mesh",
+    "PObject",
+    "Vertex",
+    "VertexList",
+    "Texture",
+    "TextureAnimation",
+    "TextureLOD",
+    "TextureTEV",
+    "Image",
+    "Palette",
+    "Material",
+    "MaterialObject",
+    "Render",
+    "PixelEngine",
+    "SceneData",
+    "SectionInfo",
+}
+
+
+def test_expected_node_classes_present():
+    missing = ESSENTIAL_NODE_CLASS_NAMES - NODE_CLASS_NAMES
+
+    assert not missing, (
+        "Node instantiation coverage is missing classes used by exporters: "
+        + ", ".join(sorted(missing))
+    )
+
+
+def _expected_value(node_cls, field_type):
+    return node_cls._default_value_for_field(field_type)
+
+
+@pytest.mark.parametrize("node_cls", NODE_CLASSES, ids=lambda cls: cls.__name__)
+def test_node_fields_have_default_values(node_cls):
+    node = node_cls(None, None)
+
+    for field in getattr(node_cls, "fields", []):
+        if not field:
+            continue
+
+        field_name = field[0]
+        field_type = field[1] if len(field) > 1 else None
+
+        assert hasattr(node, field_name), f"{node_cls.__name__} missing attribute '{field_name}'"
+
+        if not field_type:
+            continue
+
+        expected = _expected_value(node_cls, field_type)
+        value = getattr(node, field_name)
+
+        if isinstance(expected, Node):
+            assert isinstance(value, expected.__class__), (
+                f"{node_cls.__name__}.{field_name} expected instance of {expected.__class__.__name__}, "
+                f"got {type(value).__name__}"
+            )
+        elif isinstance(expected, list):
+            assert isinstance(value, list), (
+                f"{node_cls.__name__}.{field_name} expected list default, got {type(value).__name__}"
+            )
+        elif isinstance(expected, tuple):
+            assert isinstance(value, tuple), (
+                f"{node_cls.__name__}.{field_name} expected tuple default, got {type(value).__name__}"
+            )
+        else:
+            assert isinstance(value, type(expected)), (
+                f"{node_cls.__name__}.{field_name} expected {type(expected).__name__} default, "
+                f"got {type(value).__name__}"
+            )


### PR DESCRIPTION
## Summary
- walk the shared.Nodes.Classes package tree when gathering Node subclasses so every exported class, including Mesh and Texture, is instantiated in the default coverage test
- assert that essential exporter-facing node classes are present in the discovered set so regressions surface immediately

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9fb1c6ebc8326a22ab33f92028c2a